### PR TITLE
Make plugin non-intrusive: don't auto-set DOCUMENT_STORE_PYPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Addok plugin to store documents in SQLite instead of Redis to reduce memory usag
 
 - **SQLite storage**: Store documents in a SQLite database instead of Redis
 - **Memory optimization**: Reduce Redis RAM usage for large datasets
-- **Automatic registration**: Plugin registers itself when installed
 
 ## Installation
 
@@ -16,11 +15,23 @@ pip install addok-sqlite-store
 
 ## Configuration
 
-The plugin will register itself when installed, by setting the correct
-`DOCUMENT_STORE_PYPATH`.
-
-Define the path where the SQLite database will be created:
+Add the following to your Addok configuration file to activate the plugin:
 
 ```python
-SQLITE_DB_PATH = "/path/to/your/database.db"
+# Use SQLite as document store
+DOCUMENT_STORE_PYPATH = 'addok_sqlite_store.SQLiteStore'
+```
+
+The SQLite database will be created at `addok.db` by default. You can customize the path:
+
+```python
+# Optional: customize the database path
+SQLITE_DB_PATH = '/path/to/your/database.db'
+```
+
+Or use environment variables:
+
+```bash
+export ADDOK_DOCUMENT_STORE_PYPATH='addok_sqlite_store.SQLiteStore'
+export ADDOK_SQLITE_DB_PATH='/path/to/your/database.db'  # optional
 ```

--- a/addok_sqlite_store/__init__.py
+++ b/addok_sqlite_store/__init__.py
@@ -11,10 +11,10 @@ class SQLiteStore:
         self.init()
 
     def init(self):
-        db_path = (os.environ.get('ADDOK_SQLITE_DB_PATH') or 
-                   os.environ.get('SQLITE_DB_PATH') or 
-                   config.SQLITE_DB_PATH)
-        self.conn = sqlite3.connect(db_path)
+        self.db_path = (os.environ.get('ADDOK_SQLITE_DB_PATH') or 
+                        os.environ.get('SQLITE_DB_PATH') or 
+                        config.SQLITE_DB_PATH)
+        self.conn = sqlite3.connect(self.db_path)
         self.lock = Lock()
         with self.conn as conn:
             conn.execute('CREATE TABLE IF NOT EXISTS '
@@ -48,7 +48,7 @@ class SQLiteStore:
         self.lock.release()
 
     def flushdb(self):
-        os.unlink(config.SQLITE_DB_PATH)
+        os.unlink(self.db_path)
         self.init()
 
 

--- a/addok_sqlite_store/__init__.py
+++ b/addok_sqlite_store/__init__.py
@@ -11,7 +11,10 @@ class SQLiteStore:
         self.init()
 
     def init(self):
-        self.conn = sqlite3.connect(os.environ.get('SQLITE_DB_PATH') or config.SQLITE_DB_PATH)
+        db_path = (os.environ.get('ADDOK_SQLITE_DB_PATH') or 
+                   os.environ.get('SQLITE_DB_PATH') or 
+                   config.SQLITE_DB_PATH)
+        self.conn = sqlite3.connect(db_path)
         self.lock = Lock()
         with self.conn as conn:
             conn.execute('CREATE TABLE IF NOT EXISTS '

--- a/addok_sqlite_store/__init__.py
+++ b/addok_sqlite_store/__init__.py
@@ -50,5 +50,4 @@ class SQLiteStore:
 
 
 def preconfigure(config):
-    config.DOCUMENT_STORE_PYPATH = 'addok_sqlite_store.SQLiteStore'
     config.SQLITE_DB_PATH = 'addok.db'


### PR DESCRIPTION
## Summary

Makes the `addok-sqlite-store` plugin non-intrusive by removing automatic activation when installed. The plugin now requires explicit configuration to be used.

## Problem

Previously, simply installing `addok-sqlite-store` would automatically set it as the document store backend via the `preconfigure()` function. This caused issues in environments where:
- Multiple storage backends are installed (e.g., in Docker images)
- Redis or another backend should be used by default
- Users want explicit control over which backend is active

## Changes

- **Removed `DOCUMENT_STORE_PYPATH` from `preconfigure()`**: The plugin no longer auto-activates itself
- **Kept `SQLITE_DB_PATH` in `preconfigure()`**: Still provides a sensible default (`addok.db`) for the database path
- **Updated README**: Added clear instructions showing that users must explicitly set `DOCUMENT_STORE_PYPATH` to activate the plugin

## Migration Guide

After this change, users need to explicitly configure the plugin:

```python
# In your Addok configuration file
DOCUMENT_STORE_PYPATH = 'addok_sqlite_store.SQLiteStore'
```

Or via environment variable:
```bash
export ADDOK_DOCUMENT_STORE_PYPATH='addok_sqlite_store.SQLiteStore'
```

The `SQLITE_DB_PATH` configuration remains optional with a default value of `addok.db`.

## Benefits

- ✅ Plugin discovery still works via entry points
- ✅ No unexpected behavior changes when installing the plugin
- ✅ Compatible with multi-backend Docker images
- ✅ Explicit configuration makes dependencies clear
- ✅ Tests already followed this pattern (no test changes needed)
